### PR TITLE
Replace hardcoded path with something smarter.

### DIFF
--- a/scripts.go
+++ b/scripts.go
@@ -70,7 +70,7 @@ func writeScriptFile(content []byte) (file gitos.File, err error) {
 
 // gitWrapperScript forms content for git.sh script
 func gitWrapperScript() []byte {
-	scriptTemplate := `#!/bin/{shell}
+	scriptTemplate := `#!/usr/bin/env {shell}
 
 # The MIT License (MIT)
 # Copyright (c) 2013 Alvin Abad


### PR DESCRIPTION
This unbreaks a problem where caddy-git can't execute generated scripts because of a faulty shebang path on non-Linux operating systems that store shells in /usr/local.